### PR TITLE
Use Mandrill instead of AWS SES for email

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@ default['myusa']['database']['password'] = 'secret!'
 default['mysql']['database']['root_password'] = ''
 
 default['myusa']['elasticache']['endpoint'] = ''
-default['myusa']['smtp_host'] = 'email-smtp.us-east-1.amazonaws.com'
+default['myusa']['smtp_host'] = 'smtp.mandrillapp.com'
 default['myusa']['smtp_port'] = '587'
 
 # Sample certificate

--- a/templates/default/environment.rb.erb
+++ b/templates/default/environment.rb.erb
@@ -19,16 +19,15 @@ Rails.application.configure do
   config.cache_store = :dalli_store, elasticache.servers, {:expires_in => 1.day, :compress => true}
   <% end %>
 
-
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { host: '<%= @app_host %>' }
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address:    'email-smtp.us-east-1.amazonaws.com',
+    address:    'smtp.mandrillapp.com',
     port:       '587',
-    user_name:  Rails.application.secrets.aws_ses_username,
-    password:   Rails.application.secrets.aws_ses_password,
+    user_name:  Rails.application.secrets.smtp_user,
+    password:   Rails.application.secrets.smtp_pass,
     authentication: 'plain',
     enable_starttls_auto: true
   }


### PR DESCRIPTION
Note: Also requires encrypted secrets. These have been updated on staging but not production (yet)